### PR TITLE
Fixed lvalue error, removed deprecated -ta flag

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -9,10 +9,10 @@ target_include_directories(sgpu.exe PRIVATE
 set(TEST_COMP_FLAGS ${CMAKE_CXX_FLAGS})
 if(USE_ACC)
     target_link_options(sgpu.exe PRIVATE 
-        -acc -ta=tesla
+        -acc=gpu
         )
     set(TEST_COMP_FLAGS ${TEST_COMP_FLAGS} 
-        -DUSE_ACC=1 -acc -ta=tesla
+        -DUSE_ACC=1 -acc=gpu
         )
 endif()
 

--- a/src/libio/read.cpp
+++ b/src/libio/read.cpp
@@ -18,8 +18,6 @@
 #include "read.h"
 
 #include <sstream>
-#define SSTRF( x ) static_cast< std::ostringstream & >( ( std::ostringstream() << fixed << setprecision(14) << x ) ).str()
-//#define SSTRF2( x ) static_cast< std::ostringstream & >( ( std::ostringstream() << fixed << setprecision(4) << x ) ).str()
 
 double norm(int n, int l, int m, double zeta);
 

--- a/src/libio/read.h
+++ b/src/libio/read.h
@@ -18,6 +18,9 @@ using namespace std;
 
 //#define A2B 1.8897261
 
+#define SSTRF( x ) ( ( std::ostringstream() << std::fixed << std::setprecision(8) << std::scientific << (x) ).str() )
+#define SSTRF2( x ) ( ( std::ostringstream() << std::fixed << std::setprecision(14) << std::scientific << (x) ).str() )
+
 vector<string> split1(const string &s, char delim);
 
 int check_file(string filename);

--- a/src/libio/write.cpp
+++ b/src/libio/write.cpp
@@ -1,10 +1,6 @@
 #include "write.h"
 
 #include <sstream>
-#define SSTRF( x ) static_cast< std::ostringstream & >( ( std::ostringstream() << fixed << setprecision(8) << scientific << x ) ).str()
-#define SSTRF2( x ) static_cast< std::ostringstream & >( ( std::ostringstream() << fixed << setprecision(14) << scientific << x ) ).str()
-//#define SSTRF( x ) static_cast< std::ostringstream & >( ( std::ostringstream() << fixed << setprecision(8) << x ) ).str()
-//#define SSTRF2( x ) static_cast< std::ostringstream & >( ( std::ostringstream() << fixed << setprecision(14) << x ) ).str()
 
 #define A2B 1.8897261
 


### PR DESCRIPTION
Fixed the lvalue error I've run into on some Athena sessions and every other linux-64 session. Probably not the most necessary fix but it can't hurt.

Closes #19