### PR TITLE
Pin pixi-build-rattler-build to version 0.1.3

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -187,7 +187,7 @@ packages:
   - libcint 5.3.0.*
   - libcint >=5.3,<5.4.0a0
   input:
-    hash: df844fd47722f1012458d6d102ff3cbf64f17cb3c1822f399fa67a91900c892a
+    hash: 82e009c42bf2ffc70d856358d324a1482bdaaad8c4f5aafd38ccf4e4f3d6ecd0
     globs:
     - pixi.toml
 - conda: .
@@ -199,7 +199,7 @@ packages:
   - libcint 5.3.0.*
   - libcint >=5.3,<5.4.0a0
   input:
-    hash: df844fd47722f1012458d6d102ff3cbf64f17cb3c1822f399fa67a91900c892a
+    hash: 82e009c42bf2ffc70d856358d324a1482bdaaad8c4f5aafd38ccf4e4f3d6ecd0
     globs:
     - pixi.toml
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2

--- a/pixi.toml
+++ b/pixi.toml
@@ -9,7 +9,7 @@ version = "0.2.0"
 
 [package.build]
 # backend = { name = "pixi-build-cmake", version = "*" }
-backend = { name = "pixi-build-rattler-build", version = "*" }
+backend = { name = "pixi-build-rattler-build", version = "==0.1.3" }
 channels = [
   "https://prefix.dev/pixi-build-backends",
   "https://prefix.dev/conda-forge",


### PR DESCRIPTION
the build immediately fails with an error on our hpc environment with the latest version 0.1.4

- [x] Implement changes
- [x] Look through pull request changes
