### PR TITLE
removed g matrix allocation in executable

### DIFF
--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -308,7 +308,7 @@ int main(int argc, char* argv[]) {
     delete [] V, dV, Pao, coordsc;
     if(c4 > 0)  
       delete [] g;
-
+  }
 
   delete [] ang_g, ang_w;
 


### PR DESCRIPTION
Added conditional statement to allocate the g matrix(N^4) as it was being allocated even when unused, causing unnecessary bad_array_new_length errors.

- [x] Implement changes
- [x] Update documentation
- [x] Update tests
- [x] Look through pull request changes
- [x] Clean up code and retest
- [x] Increment version number

Closes ISSUE