### PR TITLE
Add interactive instructions for athena

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Please see LICENSE file for licensing information.
 - Experimental global installation to streamline routine usage when not modifying the code and remove the need for pixi shell:
   `pixi -v global install --path .`
   Requires Aug 2025 pixi update: `pixi self-update`
+- Running jobs interactively:
+  - `pixi -v run srun -p zimA10 -N1 -n2 --gpus=1 --pty /bin/bash` on athena will obtain a slurm allocation and return an interactive bash terminal on a compute node inside of the pixi configured environment with sgpu.exe on PATH
   
 Configuration of pixi can be found in the `pixi.toml` file.
 


### PR DESCRIPTION
This pull request updates the documentation in `README.md` to include instructions for running jobs interactively using Slurm on Athena. This addition clarifies how to obtain an interactive bash terminal within the pixi environment, making it easier for users to work with compute nodes.

Documentation update:

* Added a section explaining how to run jobs interactively on Athena using `pixi` and `srun`, including details about obtaining a Slurm allocation and accessing a bash terminal with the necessary environment configuration.