### PR TITLE
Make USE_ACC configurable via environment variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,11 @@ project(SlaterGPU VERSION 0.1
                   DESCRIPTION "Integrals over Slater type orbitals with GPU Acceleration"
                   LANGUAGES C CXX)
 
-set(USE_ACC True)
+set(USE_ACC ON)
+if("$ENV{USE_ACC}" STREQUAL "OFF")
+    set(USE_ACC OFF)
+endif()
+message(STATUS "USE_ACC: ${USE_ACC}")
 set(USE_MPI True)
 set(USE_OMP True)
 set(RED_DOUBLE True)


### PR DESCRIPTION
## Summary
- Replace hardcoded `set(USE_ACC True)` with env-var override: defaults `ON`, respects `USE_ACC=OFF` from shell
- Backward-compatible — default behavior unchanged
- Enables CPU-only builds of both SlaterGPU and downstream ZEST (see ZimmermanGroup/ZEST#78)

## Changes
- `CMakeLists.txt`: `set(USE_ACC True)` → `set(USE_ACC ON)` with `$ENV{USE_ACC}` override + status message

## Test plan
- [ ] ZEST CI passes for both GPU and CPU builds on the `issue-78-cpu-builds` branch (which points at this SlaterGPU branch): check ZimmermanGroup/ZEST CI runs
- [x] Verified `USE_ACC=OFF pixi install` builds SlaterGPU without GPU flags (tested via ZEST locally)
- [x] Verified default `pixi install` (no env var) still builds with GPU as before
- [x] ZEST H2_Slater regression tests pass at 1e-6 tolerance for both CPU and GPU builds locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)