### PR TITLE
Fixed inf norms for JE and treatment of charged_JE

### DIFF
--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -342,11 +342,8 @@ int main(int argc, char* argv[]) {
     }
     else if (jellium > 0)
     {
-      //int angular_num = nang;
-      //nang = size_ang;
       //do_jellium(natoms,Ne,basis,basis_aux,nrad,nang,ang_g,ang_w,prl);
       do_jellium(natoms,Ne,atno,basis,basis_aux,nrad,size_ang,ang_g,ang_w,prl);
-      //nang = angular_num;
     }
     else if (do_ps_integrals)
       compute_ps_integrals_to_disk(natoms,atno,coords,basis,basis_aux,prl,jellium);

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -21,8 +21,8 @@
 using namespace std;
 
 
-void do_jellium(int natoms, int Ne, vector<vector<double> > basis, vector<vector<double> > basis_aux,
-             int nrad, int nang, double* ang_g, double* ang_w, int prl)
+void do_jellium(int natoms, int Ne, int* atno, vector<vector<double> > basis, vector<vector<double> > basis_aux,
+             int nrad, int size_ang, double* ang_g, double* ang_w, int prl)
 {
   //if (natoms>1)
   //  return spheroidal_jellium(natoms,z0,Ne,basis,basis_aux,nrad,nang,ang_g,ang_w,prl,cu_hdl);
@@ -44,9 +44,9 @@ void do_jellium(int natoms, int Ne, vector<vector<double> > basis, vector<vector
 
   int No = Ne/2;
   //int Ne = 2*No;
-  double rs = Rc*pow(Ne,-1./3.);
+  double rs = Rc*pow(atno[0],-1./3.);
 
-  printf("  Ne: %2i  rs: %8.5f  Rc: %8.5f  Zg: %6.3f  ztg: %5.3f \n",Ne,rs,Rc,Zg,ztg);
+  printf("Z: %2i  Ne: %2i  rs: %8.5f  Rc: %8.5f  Zg: %6.3f  ztg: %5.3f \n",atno[0],Ne,rs,Rc,Zg,ztg);
   print_murak_rmax(Rc,nrad,basis);
 
   int N = basis.size();
@@ -66,8 +66,8 @@ void do_jellium(int natoms, int Ne, vector<vector<double> > basis, vector<vector
     //printf("  basis %2i  n1: %i  norm: %8.5f -> %8.5f \n",i,n1,norm0,norm1);
   }
 
-  int atno[natoms];
-  atno[0] = 1;
+  //int atno[natoms];
+  //atno[0] = 1;
   //MD float coordsf[3]; coordsf[0] = coordsf[1] = coordsf[2] = 0.;
   double coords[3]; coords[0] = coords[1] = coords[2] = 0.;
 
@@ -97,8 +97,8 @@ void do_jellium(int natoms, int Ne, vector<vector<double> > basis, vector<vector
   }
   if (!have_ints)
   {
-    compute_STEn_jellium(slater,order,Zg,ztg,rs,Rc,Ne,1,basis,nrad,nang,ang_g,ang_w,S,T,En,prl);
-    compute_C_jellium(slater,Rc,basis,basis_aux,nrad,nang,ang_g,ang_w,C);
+    compute_STEn_jellium(slater,order,Zg,ztg,rs,Rc,Ne,atno,1,basis,nrad,size_ang,ang_g,ang_w,S,T,En,prl);
+    compute_C_jellium(slater,Rc,basis,basis_aux,nrad,size_ang,ang_g,ang_w,C);
 
     write_S_En_T(N,S,En,T);
     write_C(Naux,N2,C);
@@ -110,7 +110,7 @@ void do_jellium(int natoms, int Ne, vector<vector<double> > basis, vector<vector
   {
     double* ol = new double[N2*N2];
 
-    compute_4c_ol_jellium(slater,Rc,basis,nrad,nang,ang_g,ang_w,ol,prl);
+    compute_4c_ol_jellium(slater,Rc,basis,nrad,size_ang,ang_g,ang_w,ol,prl);
     write_square(N2,ol,"olintsd",1);
 
     delete [] ol;
@@ -342,7 +342,11 @@ int main(int argc, char* argv[]) {
     }
     else if (jellium > 0)
     {
-      do_jellium(natoms,Ne,basis,basis_aux,nrad,nang,ang_g,ang_w,prl);
+      //int angular_num = nang;
+      //nang = size_ang;
+      //do_jellium(natoms,Ne,basis,basis_aux,nrad,nang,ang_g,ang_w,prl);
+      do_jellium(natoms,Ne,atno,basis,basis_aux,nrad,size_ang,ang_g,ang_w,prl);
+      //nang = angular_num;
     }
     else if (do_ps_integrals)
       compute_ps_integrals_to_disk(natoms,atno,coords,basis,basis_aux,prl,jellium);

--- a/include/jellium_ints.h
+++ b/include/jellium_ints.h
@@ -32,18 +32,18 @@ void print_murak_rmax(double Rc, int nrad, vector<vector<double> > basis);
 int get_gs1(int nrad, int nang, float* gridf, double Rc);
 int get_gs1(int nrad, int nang, double* grid, double Rc);
 
-void compute_STEn_jellium(bool use_slater, int order, double Zg, double ztg, double rs, double Rc, int Ne, bool update_norm, vector<vector<double> >& basis,
-         int nrad, int nang, double* ang_g, double* ang_w, double* S, double* T, double* En, int prl);
+void compute_STEn_jellium(bool use_slater, int order, double Zg, double ztg, double rs, double Rc, int Ne, int* atno, bool update_norm, vector<vector<double> >& basis,
+         int nrad, int size_ang, double* ang_g, double* ang_w, double* S, double* T, double* En, int prl);
 
-void compute_Vr_jellium(int order, double Zg, double ztg, double Rc, int Ne, int gs1, int gs2, double* grid, double* Vr);
-void compute_Vr_jellium(double Zg, double ztg, double Rc, int Ne, int gs1, int gs2, double* grid, double* Vr);
-void compute_Vr_jellium(double Zg, double ztg, double Rc, int Ne, int gs1, int gs2, float* grid, double* Vr);
+void compute_Vr_jellium(int order, double Zg, double ztg, double Rc, int Ne, int* atno, int gs1, int gs2, double* grid, double* Vr);
+void compute_Vr_jellium(double Zg, double ztg, double Rc, int Ne, int* atno, int gs1, int gs2, double* grid, double* Vr);
+void compute_Vr_jellium(double Zg, double ztg, double Rc, int Ne, int* atno, int gs1, int gs2, float* grid, double* Vr);
 
 void compute_C_jellium(bool slater, double Rc, vector<vector<double> > basis, vector<vector<double> > basis_aux, int nrad, int nang,
                        double* ang_g, double* ang_w, double* C);
 
 void compute_4c_ol_jellium(bool slater, double Rc, vector<vector<double> > basis,
-         int nrad, int nang, double* ang_g, double* ang_w, double* ol, int prl);
+         int nrad, int size_ang, double* ang_g, double* ang_w, double* ol, int prl);
 
 //overlap.cpp:
 void orthonormalize_mos(int Nn, int N, double* S, double* jCA);

--- a/src/integrals/jellium_ints.cpp
+++ b/src/integrals/jellium_ints.cpp
@@ -579,7 +579,7 @@ void compute_C_jellium(bool use_slater, double Rc, vector<vector<double> > basis
   return;
 }
 
-void compute_Vr_jellium(int order, double Zg, double ztg, double Rc, int Ne, int gs1, int gs2, double* grid, double* Vr)
+void compute_Vr_jellium(int order, double Zg, double ztg, double Rc, int Ne, int* atno, int gs1, int gs2, double* grid, double* Vr)
 {
   int gs = gs2;
   int gs6 = 6*gs;
@@ -632,10 +632,11 @@ void compute_Vr_jellium(int order, double Zg, double ztg, double Rc, int Ne, int
    //standard Jellium (quadratic then 1/r)
     //double c1 = -0.5*Ne/Rc;
     //double c2 = Rc*Rc;
-    double c1 = -(1.*Ne)/order/Rc;
+    int Z = atno[0];
+    double c1 = -(1.*Z)/order/Rc;
     double c2 = 1.+order;
     double c3 = pow(Rc,order);
-    double c4 = -Ne;
+    double c4 = -Z;
 
    #pragma acc parallel loop present(Vr[0:gs],grid[0:gs6])
     for (int j=0;j<gs1;j++)
@@ -716,15 +717,15 @@ void compute_Vr_jellium(int order, double Zg, double ztg, double Rc, int Ne, int
   return;
 }
 
-void compute_Vr_jellium(double Zg, double ztg, double Rc, int Ne, int gs1, int gs2, double* grid, double* Vr)
+void compute_Vr_jellium(double Zg, double ztg, double Rc, int Ne, int* atno, int gs1, int gs2, double* grid, double* Vr)
 {
   int order = read_int("JELLIUM");
   if (order<2) order = 2;
 
-  return compute_Vr_jellium(order,Zg,ztg,Rc,Ne,gs1,gs2,grid,Vr);
+  return compute_Vr_jellium(order,Zg,ztg,Rc,Ne,atno,gs1,gs2,grid,Vr);
 }
 
-void compute_Vr_jellium(double Zg, double ztg, double Rc, int Ne, int gs1, int gs2, float* gridf, double* Vr)
+void compute_Vr_jellium(double Zg, double ztg, double Rc, int Ne, int* atno, int gs1, int gs2, float* gridf, double* Vr)
 {
   int gs = gs2;
   int gs6 = 6*gs;
@@ -738,7 +739,7 @@ void compute_Vr_jellium(double Zg, double ztg, double Rc, int Ne, int gs1, int g
   for (int j=0;j<gs6;j++)
     grid[j] = gridf[j];
 
-  compute_Vr_jellium(Zg,ztg,Rc,Ne,gs1,gs2,grid,Vr);
+  compute_Vr_jellium(Zg,ztg,Rc,Ne,atno,gs1,gs2,grid,Vr);
 
   #pragma acc exit data delete(grid[0:gs6])
   delete [] grid;
@@ -877,7 +878,7 @@ void fill_permute_ol4(int N, double* ol)
 }
 
 void compute_4c_ol_jellium(bool use_slater, double Rc, vector<vector<double> > basis,
-   	 int nrad, int nang, double* ang_g, double* ang_w, double* ol, int prl)
+   	 int nrad, int size_ang, double* ang_g, double* ang_w, double* ol, int prl)
 {
   bool sgs_basis = 0;
 
@@ -890,10 +891,10 @@ void compute_4c_ol_jellium(bool use_slater, double Rc, vector<vector<double> > b
   int N2 = N*N;
   int N3 = N2*N;
 
-  int gs = nrad*nang;
+  int gs = nrad*size_ang;
   int gs6 = 6*gs;
 
-  #pragma acc enter data copyin(ang_g[0:3*nang],ang_w[0:nang])
+  #pragma acc enter data copyin(ang_g[0:3*size_ang],ang_w[0:size_ang])
 
   double* grid = new double[gs6];
   double* wt = new double[gs];
@@ -904,10 +905,10 @@ void compute_4c_ol_jellium(bool use_slater, double Rc, vector<vector<double> > b
   double Z1 = Z1J;
   //bool murak_zeta = 1;
   //generate_central_grid_2d(-1,!murak_zeta,grid,wt,Z1,nrad,nang,ang_g,ang_w);
-  generate_central_grid_3d(m_murak,grid,wt,Z1,nrad,nang,ang_g,ang_w);
+  generate_central_grid_3d(m_murak,grid,wt,Z1,nrad,size_ang,ang_g,ang_w);
   #pragma acc update self(grid[0:gs6])
 
-  int gs1 = get_gs1(nrad,nang,grid,Rc);
+  int gs1 = get_gs1(nrad,size_ang,grid,Rc);
   int gs2 = gs;
 
   if (use_slater)
@@ -917,7 +918,7 @@ void compute_4c_ol_jellium(bool use_slater, double Rc, vector<vector<double> > b
   }
  #if USE_GAUSS
   printf("  DEBUG: Gaussian only \n");
-  gs1 = nrad*nang;
+  gs1 = nrad*size_ang;
  #endif
 
   int igs = N*gs;
@@ -997,7 +998,7 @@ void compute_4c_ol_jellium(bool use_slater, double Rc, vector<vector<double> > b
   delete [] valS1;
   delete [] valS2;
 
-  #pragma acc exit data delete(ang_g[0:3*nang],ang_w[0:nang])
+  #pragma acc exit data delete(ang_g[0:3*size_ang],ang_w[0:size_ang])
   #pragma acc exit data delete(grid[0:gs6],wt[0:gs])
   delete [] grid;
   delete [] wt;
@@ -1005,8 +1006,8 @@ void compute_4c_ol_jellium(bool use_slater, double Rc, vector<vector<double> > b
   return;
 }
 
-void compute_STEn_jellium(bool use_slater, int order, double Zg, double ztg, double rs, double Rc, int Ne, bool update_norm, vector<vector<double> >& basis,
-         int nrad, int nang, double* ang_g, double* ang_w, double* S, double* T, double* En, int prl)
+void compute_STEn_jellium(bool use_slater, int order, double Zg, double ztg, double rs, double Rc, int Ne, int* atno, bool update_norm, vector<vector<double> >& basis,
+         int nrad, int size_ang, double* ang_g, double* ang_w, double* S, double* T, double* En, int prl)
 {
  //in this ftn, rs isn't used. instead, compute_Vr is already analytically evaluated.
 
@@ -1017,10 +1018,10 @@ void compute_STEn_jellium(bool use_slater, int order, double Zg, double ztg, dou
 
   //int Ne = 2*No;
 
-  int gs = nrad*nang;
+  int gs = nrad*size_ang;
   int gs6 = 6*gs;
 
-  #pragma acc enter data copyin(ang_g[0:3*nang],ang_w[0:nang])
+  #pragma acc enter data copyin(ang_g[0:3*size_ang],ang_w[0:size_ang])
 
   double* grid = new double[gs6];
   double* wt = new double[gs];
@@ -1032,10 +1033,10 @@ void compute_STEn_jellium(bool use_slater, int order, double Zg, double ztg, dou
   double Z1 = Z1J;
   bool murak_zeta = 1;
   //generate_central_grid_2d(-1,!murak_zeta,grid,wt,Z1,nrad,nang,ang_g,ang_w);
-  generate_central_grid_3d(m_murak,grid,wt,Z1,nrad,nang,ang_g,ang_w);
+  generate_central_grid_3d(m_murak,grid,wt,Z1,nrad,size_ang,ang_g,ang_w);
   #pragma acc update self(grid[0:gs6])
 
-  int gs1 = get_gs1(nrad,nang,grid,Rc);
+  int gs1 = get_gs1(nrad,size_ang,grid,Rc);
   int gs2 = gs;
   printf("  gs1: %4i  gs2: %4i \n",gs1,gs2);
 
@@ -1059,7 +1060,7 @@ void compute_STEn_jellium(bool use_slater, int order, double Zg, double ztg, dou
     double* Vr = new double[gs];
     #pragma acc enter data create(Vr[0:gs])
 
-    compute_Vr_jellium(order,Zg,ztg,Rc,Ne,gs1,gs2,grid,Vr);
+    compute_Vr_jellium(order,Zg,ztg,Rc,Ne,atno,gs1,gs2,grid,Vr);
     //compute_Vr_jellium(rs,Rc,nrad,nang,ang_g,ang_w,grid,Vr);
 
     if (use_slater)
@@ -1069,7 +1070,7 @@ void compute_STEn_jellium(bool use_slater, int order, double Zg, double ztg, dou
     }
    #if USE_GAUSS
     printf("  DEBUG: Gaussian only \n");
-    gs1 = nrad*nang;
+    gs1 = nrad*size_ang;
    #endif
 
     if (prl>1)
@@ -1077,7 +1078,7 @@ void compute_STEn_jellium(bool use_slater, int order, double Zg, double ztg, dou
       #pragma acc update self(Vr[0:gs])
       printf("\n       r      Vr: \n");
       for (int j=0;j<nrad;j++)
-        printf("   %8.5f  %9.6f \n",grid[6*nang*j+3],Vr[j*nang]);
+        printf("   %8.5f  %9.6f \n",grid[6*size_ang*j+3],Vr[j*size_ang]);
     }
 
    //evaluate basis ftns
@@ -1311,7 +1312,7 @@ void compute_STEn_jellium(bool use_slater, int order, double Zg, double ztg, dou
     print_square(N,T);
   }
 
-  #pragma acc exit data delete(ang_g[0:3*nang],ang_w[0:nang])
+  #pragma acc exit data delete(ang_g[0:3*size_ang],ang_w[0:size_ang])
   #pragma acc exit data delete(grid[0:gs6],wt[0:gs])
   delete [] grid;
   delete [] wt;


### PR DESCRIPTION
This pull request updates the jellium integral routines to consistently use the atomic number (`atno`) and the angular grid size (`size_ang`) throughout the codebase. The code now uses the right grid size for computing jellium integrals. For computing the external potential due to the positive background, Ne is replaced by the atomic number to handle charged jellium spheres correctly.


**Generalization and parameterization:**

* Updated all relevant function signatures in `src/integrals/jellium_ints.cpp` and their declarations in `include/jellium_ints.h` to accept `int* atno` (atomic numbers) and `int size_ang` (angular grid size) instead of relying on hardcoded or inferred values. This affects functions like `compute_STEn_jellium`, `compute_Vr_jellium`, and `compute_4c_ol_jellium`. [[1]](diffhunk://#diff-e6cfad948007439f232ec267048a99a7b689ed0921ad5a6473d0bb726b511518L35-R46) [[2]](diffhunk://#diff-d2d1da4416a5d88ee611955ce794bc1dff86a716053923e0c246c196d13cdfdeL582-R582) [[3]](diffhunk://#diff-d2d1da4416a5d88ee611955ce794bc1dff86a716053923e0c246c196d13cdfdeL880-R881) [[4]](diffhunk://#diff-d2d1da4416a5d88ee611955ce794bc1dff86a716053923e0c246c196d13cdfdeL1000-R1010)

* Refactored `do_jellium` in `examples/main.cpp` to accept `atno` and `size_ang` as parameters, updating all calls and removing local hardcoded atomic number arrays. [[1]](diffhunk://#diff-9fc97e4cb14a18c0e59aaf7054cb33fc596da91260dd7e7adbcef8b406ed57b6L24-R25) [[2]](diffhunk://#diff-9fc97e4cb14a18c0e59aaf7054cb33fc596da91260dd7e7adbcef8b406ed57b6L69-R70) [[3]](diffhunk://#diff-9fc97e4cb14a18c0e59aaf7054cb33fc596da91260dd7e7adbcef8b406ed57b6L345-R349)

**Correctness and output improvements:**

* Changed calculations and print statements to use `atno[0]` (atomic number) instead of `Ne` (number of electrons) where appropriate, ensuring that the correct physical values are used in both computation and output. [[1]](diffhunk://#diff-9fc97e4cb14a18c0e59aaf7054cb33fc596da91260dd7e7adbcef8b406ed57b6L47-R49) [[2]](diffhunk://#diff-d2d1da4416a5d88ee611955ce794bc1dff86a716053923e0c246c196d13cdfdeL635-R639)

**Consistent use of angular grid size:**

* Replaced all instances of `nang` with `size_ang` in grid allocations, kernel launches, and data movement for angular grids, ensuring that the angular grid size is consistently applied throughout the code. [[1]](diffhunk://#diff-d2d1da4416a5d88ee611955ce794bc1dff86a716053923e0c246c196d13cdfdeL893-R897) [[2]](diffhunk://#diff-d2d1da4416a5d88ee611955ce794bc1dff86a716053923e0c246c196d13cdfdeL907-R911) [[3]](diffhunk://#diff-d2d1da4416a5d88ee611955ce794bc1dff86a716053923e0c246c196d13cdfdeL920-R921) [[4]](diffhunk://#diff-d2d1da4416a5d88ee611955ce794bc1dff86a716053923e0c246c196d13cdfdeL1020-R1024) [[5]](diffhunk://#diff-d2d1da4416a5d88ee611955ce794bc1dff86a716053923e0c246c196d13cdfdeL1035-R1039) [[6]](diffhunk://#diff-d2d1da4416a5d88ee611955ce794bc1dff86a716053923e0c246c196d13cdfdeL1072-R1081) [[7]](diffhunk://#diff-d2d1da4416a5d88ee611955ce794bc1dff86a716053923e0c246c196d13cdfdeL1314-R1315)

**Function call and implementation updates:**

* Updated all internal and external calls to the affected functions in both `examples/main.cpp` and `src/integrals/jellium_ints.cpp` to match the new parameter lists, ensuring code consistency and preventing mismatches. [[1]](diffhunk://#diff-9fc97e4cb14a18c0e59aaf7054cb33fc596da91260dd7e7adbcef8b406ed57b6L100-R101) [[2]](diffhunk://#diff-9fc97e4cb14a18c0e59aaf7054cb33fc596da91260dd7e7adbcef8b406ed57b6L113-R113) [[3]](diffhunk://#diff-d2d1da4416a5d88ee611955ce794bc1dff86a716053923e0c246c196d13cdfdeL1062-R1063)
