### PR TITLE
Drop consumer-side libcint pkg-config probe from Config.cmake.in

### DIFF
--- a/SlaterGPUConfig.cmake.in
+++ b/SlaterGPUConfig.cmake.in
@@ -21,8 +21,6 @@ include("${CMAKE_CURRENT_LIST_DIR}/SlaterGPUTargets.cmake")
 set(SlaterGPU_LIBRARIES SlaterGPU::SlaterGPU SlaterGPU::io)
 if(@DO_GTO@)
     list(APPEND SlaterGPU_LIBRARIES SlaterGPU::cintw)
-    find_dependency(PkgConfig REQUIRED)
-    pkg_check_modules(LIBCINT REQUIRED libcint>=5.3.0)
 endif()
 
 set(SlaterGPU_INCLUDE_DIRS "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@")


### PR DESCRIPTION
## Summary

- Removes the `pkg_check_modules(LIBCINT REQUIRED libcint>=5.3.0)` (and the `find_dependency(PkgConfig REQUIRED)` it required) from `SlaterGPUConfig.cmake.in`.
- The probe had no functional value — its `LIBCINT_*` output vars were never wired into `SlaterGPU_LIBRARIES` or any imported target. libcint is already carried as a transitive dep via `IMPORTED_LINK_DEPENDENT_LIBRARIES_RELEASE -> SlaterGPU::cint` (auto-promoted from the `find_library` path during `install(EXPORT)`).
- The probe also broke downstream pixi consumer builds whenever libcint isn't exposed via `pkg-config` in the consumer's environment — surfacing as `No package 'libcint' found` at consumer-side `find_package(SlaterGPU)` time. This was previously masked in ZEST and XCtera by a workaround block that bypassed CONFIG mode entirely (see #88).

## Why it's safe

After this change, a consumer doing `find_package(SlaterGPU)` + `target_link_libraries(... SlaterGPU::cintw)` still gets a clean link chain — verified locally with both ZEST and XCtera builds, both Release and Debug consumer configurations. `ldd` on the resulting binaries shows the full chain:

```
libio.so => ...
libcintw.so => ...
libcint.so.5 => ...
```

CMake's documented `IMPORTED_CONFIGURATIONS` auto-fallback handles Debug consumers linking against the only-available Release artifacts, so no `MAP_IMPORTED_CONFIG_*` shim is needed.

## Sequencing

This PR should merge **before** the companion ZEST and XCtera cleanup PRs (filed under [#88](https://github.com/ZimmermanGroup/SlaterGPU/issues/88)), since those PRs delete the workaround that has been masking this bug.

## Test plan

- [x] Local: pixi build of SlaterGPU from this branch succeeds
- [x] Local: pixi build of ZEST (with workaround removed) against this SlaterGPU succeeds; `ldd` clean
- [x] Local: pixi build of XCtera (with workaround removed) against this SlaterGPU succeeds; `ldd` clean
- [x] Local: `cmake -DCMAKE_BUILD_TYPE=Debug` configure of ZEST against this SlaterGPU produces a clean `link.txt` with all four expected artifacts
- [ ] CI green

Refs #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)